### PR TITLE
Add USE_MATHJAX = YES to Doxyfile

### DIFF
--- a/catkin_tools_document/doxygen.py
+++ b/catkin_tools_document/doxygen.py
@@ -67,7 +67,8 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
         'PROJECT_NAME': package.name,
         'OUTPUT_DIRECTORY': output_path,
         'TAB_SIZE': conf.get('tab_size', '8'),
-        'TAGFILES': ' '.join(tagfiles)
+        'TAGFILES': ' '.join(tagfiles),
+        'USE_MATHJAX': True
     })
 
     with open(os.path.join(docs_build_path, 'Doxyfile'), 'w') as f:


### PR DESCRIPTION
See http://www.stack.nl/~dimitri/doxygen/manual/config.html#cfg_use_mathjax

Without this, the `Doxyfile` autogenerated by `catkin document` doesn't have `USE_MATHJAX = YES` and it defaults to `LaTeX` to convert all non-inline equations into images.
This fails with `catkin document` because it calls `catkin env -si` (where `-i` ignores the environment) and calling `pdflatex` fails with a coredump because it can't write somewhere:
``` bash
Generating bitmaps for formulas in HTML...
lstat(./latex) failed ...
./latex: No such file or directory
latex: ../../../texk/kpathsea/progname.c:316: remove_dots: Assertion `ret' failed.
Aborted (core dumped)
error: Problems running latex. Check your installation or look for typos in _formulas.tex and check _formulas.log!
Generating image form_7.png for formula
lstat(./dvips) failed ...
./dvips: No such file or directory
dvips: ../../../texk/kpathsea/progname.c:316: remove_dots: Assertion `ret' failed.
Aborted (core dumped)
error: Problems running dvips. Check your installation!
```

If we pass `PATH=/usr/bin` to `catkin env` (even with `-si`) it works, but IMHO it's better to use `mathjax` because that way we don't even rely on having `texlive` (`LaTeX`) installed on the system when building the documentation, and `mathjax` is currently well supported by most browsers.