### PR TITLE
Doxygen fixes/improvements

### DIFF
--- a/catkin_tools_document/document.py
+++ b/catkin_tools_document/document.py
@@ -60,6 +60,16 @@ def create_package_job(context, package, package_path, deps):
 
     # Load rosdoc config, if it exists.
     rosdoc_yaml_path = os.path.join(package_path_abs, 'rosdoc.yaml')
+    for export in package.exports:
+        if export.tagname == "rosdoc":
+            config = export.attributes.get('config', '')
+            if config:
+                rosdoc_yaml_path_temp = os.path.join(package_path_abs, config)
+                if os.path.exists(rosdoc_yaml_path_temp):
+                    # Stop if configuration is found which exists
+                    rosdoc_yaml_path = rosdoc_yaml_path_temp
+                    break
+
     if os.path.exists(rosdoc_yaml_path):
         with open(rosdoc_yaml_path) as f:
             rosdoc_conf = yaml.load(f)

--- a/catkin_tools_document/document.py
+++ b/catkin_tools_document/document.py
@@ -54,9 +54,9 @@ from .util import which
 
 
 def create_package_job(context, package, package_path, deps):
-    docs_space = os.path.join(context.build_space_abs, '..', 'docs', package.name)
-    docs_build_space = os.path.join(context.build_space_abs, 'docs', package.name)
-    package_path_abs = os.path.join(context.source_space_abs, package_path)
+    docs_space = os.path.realpath(os.path.join(context.build_space_abs, '..', 'docs', package.name))
+    docs_build_space = os.path.realpath(os.path.join(context.build_space_abs, 'docs', package.name))
+    package_path_abs = os.path.realpath(os.path.join(context.source_space_abs, package_path))
 
     # Load rosdoc config, if it exists.
     rosdoc_yaml_path = os.path.join(package_path_abs, 'rosdoc.yaml')

--- a/catkin_tools_document/doxygen.py
+++ b/catkin_tools_document/doxygen.py
@@ -60,6 +60,7 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
         'EXAMPLE_PATTERNS': conf.get('example_patterns', ''),
         'EXCLUDE_PATTERNS': conf.get('exclude_patterns', ''),
         'EXCLUDE_SYMBOLS': conf.get('exclude_symbols', ''),
+        'FILE_PATTERNS': conf.get('file_patterns', doxyfile_conf['FILE_PATTERNS']),  # Use predefined values as default if not defined
         'GENERATE_HTML': True,
         'GENERATE_XML': True,
         'SEARCHENGINE': True,
@@ -75,12 +76,6 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
         'USE_MATHJAX': True,
         'USE_MDFILE_AS_MAINPAGE': mdfile
     })
-
-    # FILE_PATTERNS needs a seperated update of the config as it it is already
-    # in the base config and should only be overriden in case it is defined.
-    file_patterns = conf.get('file_patterns', '')
-    if file_patterns:
-        doxyfile_conf.update({'FILE_PATTERNS': file_patterns})
 
     with open(os.path.join(docs_build_path, 'Doxyfile'), 'w') as f:
         _write_config(f, doxyfile_conf)

--- a/catkin_tools_document/doxygen.py
+++ b/catkin_tools_document/doxygen.py
@@ -76,6 +76,12 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
         'USE_MDFILE_AS_MAINPAGE': mdfile
     })
 
+    # FILE_PATTERNS needs a seperated update of the config as it it is already
+    # in the base config and should only be overriden in case it is defined.
+    file_patterns = conf.get('file_patterns', '')
+    if file_patterns:
+        doxyfile_conf.update({'FILE_PATTERNS': file_patterns})
+
     with open(os.path.join(docs_build_path, 'Doxyfile'), 'w') as f:
         _write_config(f, doxyfile_conf)
     return 0

--- a/catkin_tools_document/doxygen.py
+++ b/catkin_tools_document/doxygen.py
@@ -51,6 +51,9 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
                                             '%s/%s' % (build_depend_name, subdir)
             tagfiles.append('%s=%s' % (depend_docs_tagfile, depend_docs_relative_path))
 
+    mdfile = conf.get('use_mdfile_as_mainpage', '')
+    mdfile = os.path.join(source_path, mdfile) if mdfile else mdfile
+
     doxyfile_conf = copy.copy(_base_config)
     doxyfile_conf.update({
         'ALIASES': conf.get('aliases', ''),
@@ -64,13 +67,13 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
         'HTML_HEADER': header_filename,
         'HTML_OUTPUT': output_dir,
         'IMAGE_PATH': conf.get('image_path', source_path),
-        'INPUT': source_path + " " + conf.get('use_mdfile_as_mainpage', ""),
+        'INPUT': " ".join([source_path, mdfile]),
         'PROJECT_NAME': package.name,
         'OUTPUT_DIRECTORY': output_path,
         'TAB_SIZE': conf.get('tab_size', '8'),
         'TAGFILES': ' '.join(tagfiles),
         'USE_MATHJAX': True,
-        'USE_MDFILE_AS_MAINPAGE': conf.get('use_mdfile_as_mainpage', "")
+        'USE_MDFILE_AS_MAINPAGE': mdfile
     })
 
     with open(os.path.join(docs_build_path, 'Doxyfile'), 'w') as f:

--- a/catkin_tools_document/doxygen.py
+++ b/catkin_tools_document/doxygen.py
@@ -64,12 +64,13 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
         'HTML_HEADER': header_filename,
         'HTML_OUTPUT': output_dir,
         'IMAGE_PATH': conf.get('image_path', source_path),
-        'INPUT': source_path,
+        'INPUT': source_path + " " + conf.get('use_mdfile_as_mainpage', ""),
         'PROJECT_NAME': package.name,
         'OUTPUT_DIRECTORY': output_path,
         'TAB_SIZE': conf.get('tab_size', '8'),
         'TAGFILES': ' '.join(tagfiles),
-        'USE_MATHJAX': True
+        'USE_MATHJAX': True,
+        'USE_MDFILE_AS_MAINPAGE': conf.get('use_mdfile_as_mainpage', "")
     })
 
     with open(os.path.join(docs_build_path, 'Doxyfile'), 'w') as f:

--- a/catkin_tools_document/doxygen.py
+++ b/catkin_tools_document/doxygen.py
@@ -52,7 +52,8 @@ def generate_doxygen_config(logger, event_queue, conf, package, recursive_build_
             tagfiles.append('%s=%s' % (depend_docs_tagfile, depend_docs_relative_path))
 
     mdfile = conf.get('use_mdfile_as_mainpage', '')
-    mdfile = os.path.join(source_path, mdfile) if mdfile else mdfile
+    if mdfile:
+        mdfile = os.path.join(source_path, mdfile)
 
     doxyfile_conf = copy.copy(_base_config)
     doxyfile_conf.update({


### PR DESCRIPTION
- call realpath on all paths going to the builders, As Doxygen has some issues with reading paths with symlinks, https://github.com/doxygen/doxygen/issues/3518
- Implement 'use_mdfile_as_mainpage' for doxygen (https://stackoverflow.com/a/13442157)
- Actually check exports for a config which exists, otherwise use `rosdoc.yaml` as backup
- Implement 'FILE_PATTERNS' in doxygen config