### PR TITLE
Add pydoctor as epydoc fallback.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,6 @@ setup(
         'catkin_pkg',
         'catkin_tools>=0.4.4',
         'catkin_sphinx',
+#        'pydoctor',
         'sphinx']
 )


### PR DESCRIPTION
Basic support for documenting python/epydoc packages using pydoctor. Haven't dug into the intersphinx stuff yet, but this seems to work at a basic level. With this in, we can cut a new release (#12).

Note that currently the `pydoctor` dependency is commented out as there isn't a release of pydoctor on pypi which supports Py3. So for that to work, currently you must install pydoctor from source. This can be removed on the next release, see: https://github.com/twisted/pydoctor/pull/185

FYI @MatthijsBurgh @tspicer01