### PR TITLE
(doxygen) remove obsolete PERL_PATH

### DIFF
--- a/catkin_tools_document/doxygen.py
+++ b/catkin_tools_document/doxygen.py
@@ -224,7 +224,6 @@ _base_config = {
     'ALLEXTERNALS': False,
     'EXTERNAL_GROUPS': False,
     'EXTERNAL_PAGES': False,
-    'PERL_PATH': '/usr/bin/perl',
     'CLASS_DIAGRAMS': True,
     'HIDE_UNDOC_RELATIONS': True,
     'HAVE_DOT': True,


### PR DESCRIPTION
`PERL_PATH` has become obsolete
```
Warnings   << upower_ros:rosdoc_doxygen /home/amigo/ros/noetic/system/logs/upower_ros/document.rosdoc_doxygen.000.log
warning: Tag 'PERL_PATH' at line 100 of file '/home/amigo/ros/noetic/system/build/docs/upower_ros/Doxyfile' has become obsolete.
         To avoid this warning please remove this line from your configuration file or upgrade it using "doxygen -u"
```
(https://github.com/tue-robotics/tue-robotics.github.io/runs/3573352098?check_suite_focus=true#step:4:2144)
